### PR TITLE
fix: handle unhandled rejection in SES in code bundling

### DIFF
--- a/contract-1/package.json
+++ b/contract-1/package.json
@@ -29,11 +29,14 @@
     "@agoric/notifier": "^0.3.35",
     "@agoric/store": "^0.6.10",
     "@agoric/zoe": "^0.21.3",
-    "@endo/bundle-source": "^2.1.1",
+    "@endo/bundle-source": "^3.0.2",
     "@endo/eventual-send": "^0.14.8",
     "@endo/init": "^0.5.37",
     "@endo/marshal": "^0.6.3",
-    "@endo/ses-ava": "^0.2.32"
+    "@endo/ses-ava": "^0.2.32",
+    "@types/jszip": "^3.4.1",
+    "eslint-plugin-jsdoc": "^48.0.2",
+    "jszip": "^3.10.1"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
This commit addresses an unhandled rejection error encountered during the code bundling process. The issue originated from the "@endo/bundle-source" dependency, version "^2.1.1". The error, identified as SES_UNHANDLED_REJECTION, was caused by a TypeError related to assigning a value to the read-only constructor property of an object. The detailed error message is as follows:

TypeError: Cannot assign to read only property constructor of object [object Object].